### PR TITLE
Add user_code argument to verification entry points

### DIFF
--- a/verifications/module_0.py
+++ b/verifications/module_0.py
@@ -36,7 +36,7 @@ def get_target_points(task):
     return target_points[task]
 
 
-def test_drive(robot, image, td: dict):
+def test_drive(robot, image, td: dict, user_code=None):
     """Test for lesson 1: Test drive"""
 
     # init result dictionary
@@ -94,7 +94,7 @@ def test_drive(robot, image, td: dict):
     return image, td, text, result
 
 
-def license_to_drive(robot, image, td: dict):
+def license_to_drive(robot, image, td: dict, user_code=None):
     """Test for lesson 2: License to drive"""
     # init test data dictionary
     if not td:
@@ -123,7 +123,7 @@ def draw_trajectory(image, points, color, width, restore):
         prev_point = point
 
 
-def sandbox(robot, image, td: dict):
+def sandbox(robot, image, td: dict, user_code=None):
     """Drawing trajectory at lesson Drawing"""
 
     # init result dictionary

--- a/verifications/module_1.py
+++ b/verifications/module_1.py
@@ -32,7 +32,7 @@ def delta_points(point_0, point_1):
                      ((point_0[1] - point_1[1]) ** 2))
 
 
-def short_distance_race(robot, image, td: dict):
+def short_distance_race(robot, image, td: dict, user_code=None):
     """Test for lesson 3: Short distance race"""
 
     result = {
@@ -96,7 +96,7 @@ def short_distance_race(robot, image, td: dict):
 
     return image, td, text, result
 
-def maneuvering(robot, image, td: dict):
+def maneuvering(robot, image, td: dict, user_code=None):
     """Test for lesson 4: Maneuvering"""
 
     result = {
@@ -212,7 +212,7 @@ def calculate_target_point(rb, targets):
     return res
 
 
-def long_distance_race(robot, image, td: dict):
+def long_distance_race(robot, image, td: dict, user_code=None):
     """Test for lesson 5: Long distance race."""
 
     result = {

--- a/verifications/module_2.py
+++ b/verifications/module_2.py
@@ -25,7 +25,7 @@ def get_target_points(task):
     return target_points.get(task, [])
 
 
-def headlights(robot, image, td: dict):
+def headlights(robot, image, td: dict, user_code=None):
     """Test for lesson 6: Headlights."""
 
     result = {
@@ -114,7 +114,7 @@ def headlights(robot, image, td: dict):
     return image, td, text, result
 
 
-def alarm(robot, image, td: dict):
+def alarm(robot, image, td: dict, user_code=None):
     """lesson 7: Alarm - Detects LED blinking with 1-second intervals."""
 
     result = {

--- a/verifications/module_3.py
+++ b/verifications/module_3.py
@@ -32,7 +32,7 @@ def get_target_points(task):
 
 
 
-def move_function(robot, image, td: dict):
+def move_function(robot, image, td: dict, user_code=None):
     """Test: Robot must turn 180 degrees."""
     # overlay robot info on image
     image = robot.draw_info(image)
@@ -79,7 +79,7 @@ def move_function(robot, image, td: dict):
 
 
 
-def electric_motor(robot, image, td: dict):
+def electric_motor(robot, image, td: dict, user_code=None):
     """Test for lesson 8: Electric motor"""
     result = {
         "success": True,
@@ -189,7 +189,7 @@ def rotate_image(image, angle):
     result = cv2.warpAffine(image, rot_mat, image.shape[1::-1], flags=cv2.INTER_LINEAR)
     return result
 
-def differential_drive(robot, image, td):
+def differential_drive(robot, image, td, user_code=None):
     """Verification function for driving straight assignment"""
     result = {
         "success": True,

--- a/verifications/module_4.py
+++ b/verifications/module_4.py
@@ -22,7 +22,7 @@ def get_target_points(task):
     """Retrieve target points for a given task."""
     return target_points.get(task, [])
 
-def encoders(robot, image, td):
+def encoders(robot, image, td, user_code=None):
     """Verification function for Lesson 1: Encoder"""
     result = {
         "success": True,

--- a/verifications/module_5.py
+++ b/verifications/module_5.py
@@ -23,7 +23,7 @@ def get_target_points(task):
     """Retrieve target points for a given task."""
     return target_points.get(task, [])
 
-def line_sensor_intro(robot, image, td):
+def line_sensor_intro(robot, image, td, user_code=None):
     result = {
         "success": True,
         "description": "Verifying sensor values...",

--- a/verifications/module_6.py
+++ b/verifications/module_6.py
@@ -35,7 +35,7 @@ def get_target_points(task):
     return target_points.get(task, [])
 
 
-def hello_mqtt_variables(robot, image, td):
+def hello_mqtt_variables(robot, image, td, user_code=None):
     result = {
         "success": True,  # Changed to True to keep running
         "description": "Awaiting STATUS message...",
@@ -143,7 +143,7 @@ def hello_mqtt_variables(robot, image, td):
     return image, td, text, result
 
 
-def mission_time_report(robot, image, td):
+def mission_time_report(robot, image, td, user_code=None):
     result = {
         "success": True,  # Changed to True to keep running
         "description": "Awaiting mission report...",
@@ -252,7 +252,7 @@ def mission_time_report(robot, image, td):
     return image, td, text, result
 
 
-def sensor_log_summary(robot, image, td):
+def sensor_log_summary(robot, image, td, user_code=None):
     result = {
         "success": True,  # Changed to True to keep running
         "description": "Awaiting LOG messages...",
@@ -375,7 +375,7 @@ def sensor_log_summary(robot, image, td):
 
     return image, td, text, result
 
-def list_operations_check(robot, image, td):
+def list_operations_check(robot, image, td, user_code=None):
     result = {
         "success": True,  # Changed to True to keep running
         "description": "Awaiting LIST messages...",
@@ -498,7 +498,7 @@ def list_operations_check(robot, image, td):
     return image, td, text, result
 
 
-def introduction_to_variables_and_conditional_statements(robot, image, td):
+def introduction_to_variables_and_conditional_statements(robot, image, td, user_code=None):
     """Check that at least one sensor is reported as ON LINE within the allotted time."""
     result = {
         "success": True,
@@ -540,7 +540,7 @@ def introduction_to_variables_and_conditional_statements(robot, image, td):
     return image, td, text, result
 
 
-def loops_and_conditional_logic(robot, image, td):
+def loops_and_conditional_logic(robot, image, td, user_code=None):
     result = {
         "success": True,
         "description": "Collecting sensor data...",
@@ -591,7 +591,7 @@ def loops_and_conditional_logic(robot, image, td):
     return image, td, text, result
 
 
-def array_and_processing_data(robot, image, td):
+def array_and_processing_data(robot, image, td, user_code=None):
     result = {
         "success": True,
         "description": "Checking for values above 200...",

--- a/verifications/module_7.py
+++ b/verifications/module_7.py
@@ -26,24 +26,56 @@ def get_target_points(task):
     """Retrieve target points for a given task."""
     return target_points.get(task, [])
 
-def basic_line_follower(robot, image, td: dict):
+def basic_line_follower(robot, image, td: dict, user_code=None):
     """Place checkpoints only in cells 1 and 2 (first row, first two cells)"""
     cell_indices = [0, 1,4]  # Cells 1, 2
-    return checkpoint_verification_grid(robot, image, td, cell_indices, 20, "basic_line_follower")
+    return checkpoint_verification_grid(
+        robot,
+        image,
+        td,
+        cell_indices,
+        20,
+        "basic_line_follower",
+        user_code=user_code,
+    )
 
 
-def pi(robot, image, td: dict):
+def pi(robot, image, td: dict, user_code=None):
     """Place checkpoints in cells 2, 3, 5, 6, 8, 9"""
     cell_indices = [3,6,7,10,11]  # Cells 2, 3, 5, 6, 8, 9 (0-indexed)
-    return checkpoint_verification_grid(robot, image, td, cell_indices, 30, "pi")
+    return checkpoint_verification_grid(
+        robot,
+        image,
+        td,
+        cell_indices,
+        30,
+        "pi",
+        user_code=user_code,
+    )
 
 
-def pid(robot, image, td: dict):
+def pid(robot, image, td: dict, user_code=None):
     """Place checkpoints in all 12 cells"""
     cell_indices = [0,1,3,4,5,6,7,8,9,10,11]  # All cells
-    return checkpoint_verification_grid(robot, image, td, cell_indices, 50, "pid")
+    return checkpoint_verification_grid(
+        robot,
+        image,
+        td,
+        cell_indices,
+        50,
+        "pid",
+        user_code=user_code,
+    )
 
-def checkpoint_verification_grid(robot, image, td, cell_indices, verification_time, task_name):
+def checkpoint_verification_grid(
+    robot,
+    image,
+    td,
+    cell_indices,
+    verification_time,
+    task_name,
+    user_code=None,
+):
     """
     Crops the image to a region of interest (ROI), divides it into a 3x4 grid (3 rows, 4 cols),
     and places checkpoints only in specified cells on the black line.

--- a/verifications/module_8.py
+++ b/verifications/module_8.py
@@ -23,7 +23,7 @@ def get_target_points(task):
     """Retrieve target points for a given task."""
     return target_points.get(task, [])
     
-def telemetry_heartbeat_health(robot, image, td):
+def telemetry_heartbeat_health(robot, image, td, user_code=None):
     result = {
         "success": True,
         "description": "Verifying robot status messages...",
@@ -129,7 +129,7 @@ def telemetry_heartbeat_health(robot, image, td):
     return image, td, text, result
 
 
-def line_sensor_leds(robot, image, td: dict):
+def line_sensor_leds(robot, image, td: dict, user_code=None):
     """Verification: Check if LEDs flash with 2-second ON and 2-second OFF intervals"""
 
     result = {

--- a/verifications/module_9.py
+++ b/verifications/module_9.py
@@ -27,7 +27,7 @@ def get_target_points(task):
     """Retrieve target points for a given task."""
     return target_points.get(task, [])
 
-def fog_of_war_survey(robot, image, td):
+def fog_of_war_survey(robot, image, td, user_code=None):
     """
     Assignment 1: Fog of War - Explore and reveal the map
     """
@@ -162,7 +162,7 @@ def fog_of_war_survey(robot, image, td):
 
     return image, td, text, result
     
-def miniral_scanner_sweep(robot, image, td):
+def miniral_scanner_sweep(robot, image, td, user_code=None):
     """
     Lesson 2.7: Multi-Point Mineral Survey
     Visit 5 scanning zones and activate scanner at each zone
@@ -404,7 +404,7 @@ def miniral_scanner_sweep(robot, image, td):
     return image, td, text, result
 
 
-def docking(robot, image, td):
+def docking(robot, image, td, user_code=None):
     """
     Auto-dock verification - robot must achieve charging >= 10
     """


### PR DESCRIPTION
### Motivation
- Verification entry points must accept an extra `user_code` argument so external callers can provide the submitted user program to checks and helper verifications.
- The module-7 checkpoint helper is sometimes invoked directly, so its signature must accept `user_code` and propagate it from the wrappers.

### Description
- Added an optional `user_code=None` parameter to all exported verification functions across `verifications/module_0.py` through `verifications/module_9.py` so calls remain backwards-compatible.
- Updated `basic_line_follower`, `pi`, and `pid` in `verifications/module_7.py` to forward `user_code` to the shared `checkpoint_verification_grid` helper and extended that helper to accept `user_code=None`.
- Adjusted various other helper/verification functions to include the new `user_code` parameter in their signatures (examples: `test_drive`, `license_to_drive`, `sandbox`, `short_distance_race`, `maneuvering`, `long_distance_race`, `headlights`, `alarm`, `move_function`, `electric_motor`, `differential_drive`, `encoders`, `line_sensor_intro`, `hello_mqtt_variables`, `mission_time_report`, `sensor_log_summary`, `list_operations_check`, `introduction_to_variables_and_conditional_statements`, `loops_and_conditional_logic`, `array_and_processing_data`, `telemetry_heartbeat_health`, `line_sensor_leds`, `fog_of_war_survey`, `miniral_scanner_sweep`, `docking`).
- Changes preserve existing behavior by making `user_code` optional and only threading it where required.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69722be5820883328f26858c45f58c5b)