### PR TITLE
Update module 1 lessons to missions 1.1–1.7 and renumber subsequent lessons

### DIFF
--- a/lessons-list.json
+++ b/lessons-list.json
@@ -38,27 +38,59 @@
     "str_id": "module_1",
     "lessons": [
       {
-        "str_id": "short_distance_race",
-        "url": "https://raw.githubusercontent.com/autolab-fi/lineRobot-micropython-course/main/lessons/module_1/short_distance_race.md",
+        "str_id": "welcome",
+        "name": "Mission 1.1. Welcome to Artemis Support Program",
+        "url": "https://raw.githubusercontent.com/autolab-fi/lineRobot-micropython-course/main/lessons/module_1/mission_1.1.md",
         "sn": 3,
-        "name": "Short distance race",
-        "description": "Using library functions to move a specific distance, both forward and backward.",
+        "description": "Join the Artemis Support Program, get familiar with the Mission Control Interface, and connect to the Lunar Terrain Vehicle (LTV).",
+        "template": "# Write code here"
+      },
+      {
+        "str_id": "test_drive",
+        "name": "Mission 1.2. Test drive",
+        "url": "https://raw.githubusercontent.com/autolab-fi/lineRobot-micropython-course/main/lessons/module_1/mission_1.2.md",
+        "sn": 4,
+        "description": "Understand what a robot object is and run your first movement code.",
+        "template": "# Write code here"
+      },
+      {
+        "str_id": "license_to_drive",
+        "name": "Mission 1.3. License to drive",
+        "url": "https://raw.githubusercontent.com/autolab-fi/lineRobot-micropython-course/main/lessons/module_1/mission_1.3.md",
+        "sn": 5,
+        "description": "Understand the structure of a Python robotics program and write your own control code.",
+        "template": "# Write code here"
+      },
+      {
+        "str_id": "directional_movement",
+        "name": "Mission 1.4. Directional Movement",
+        "url": "https://raw.githubusercontent.com/autolab-fi/lineRobot-micropython-course/main/lessons/module_1/mission_1.4.md",
+        "sn": 6,
+        "description": "Explore functions for moving the robot specific distances forward and backward.",
+        "template": "# Write code here"
+      },
+      {
+        "str_id": "python_variables_&_commands",
+        "name": "Mission 1.5. Python Variables & Commands",
+        "url": "https://raw.githubusercontent.com/autolab-fi/lineRobot-micropython-course/main/lessons/module_1/mission_1.5.md",
+        "sn": 7,
+        "description": "Learn to store data using variables, perform basic arithmetic, and use variables to control the robot and report status.",
         "template": "# Write code here"
       },
       {
         "str_id": "maneuvering",
-        "url": "https://raw.githubusercontent.com/autolab-fi/lineRobot-micropython-course/main/lessons/module_1/maneuvering.md",
-        "sn": 4,
-        "name": "Maneuvering",
-        "description": "Turning right and left in place. Task: Read data from a file and write it to another.",
+        "name": "Mission 1.6. Maneuvering",
+        "url": "https://raw.githubusercontent.com/autolab-fi/lineRobot-micropython-course/main/lessons/module_1/mission_1.6.md",
+        "sn": 8,
+        "description": "Master the robot's steering with 90-degree turns and precise angle-based turns.",
         "template": "# Write code here"
       },
       {
-        "str_id": "long_distance_race",
-        "url": "https://raw.githubusercontent.com/autolab-fi/lineRobot-micropython-course/main/lessons/module_1/long_distance_race.md",
-        "sn": 5,
-        "name": "Fruit Ninja",
-        "description": "Writing a program with a sequence of commands to move along a trajectory depicted in the diagram.",
+        "str_id": "sequential_navigation",
+        "name": "Mission 1.7. Sequential navigation",
+        "url": "https://raw.githubusercontent.com/autolab-fi/lineRobot-micropython-course/main/lessons/module_1/mission_1.7.md",
+        "sn": 9,
+        "description": "Create a multi-waypoint route and learn to document your code using comments.",
         "template": "# Write code here"
       }
     ]
@@ -72,7 +104,7 @@
       {
         "str_id": "headlights",
         "url": "https://raw.githubusercontent.com/autolab-fi/lineRobot-micropython-course/main/lessons/module_2/headlights.md",
-        "sn": 6,
+        "sn": 10,
         "name": "Headlights",
         "description": "Understanding how LEDs work. Task: Turning on LEDs.",
         "template": "# Write code here"
@@ -80,7 +112,7 @@
       {
         "str_id": "alarm",
         "url": "https://raw.githubusercontent.com/autolab-fi/lineRobot-micropython-course/main/lessons/module_2/alarm.md",
-        "sn": 7,
+        "sn": 11,
         "name": "Robot's alarm",
         "description": "More about the digitalWrite() and pinMode() functions. Task: Blinking LEDs.",
         "template": "# Write code here"
@@ -96,7 +128,7 @@
       {
         "str_id": "differential_drive",
         "url": "https://raw.githubusercontent.com/autolab-fi/lineRobot-micropython-course/main/lessons/module_3/differential_drive.md",
-        "sn": 8,
+        "sn": 12,
         "name": "Differential drive",
         "description": "An introduction to the robot's kinematics. Task: Experiment with functions for moving the robot forward.",
         "template": "# Write code here"
@@ -104,7 +136,7 @@
       {
         "str_id": "move_function",
         "url": "https://raw.githubusercontent.com/autolab-fi/lineRobot-micropython-course/main/lessons/module_3/move_function.md",
-        "sn": 9,
+        "sn": 13,
         "name": "Movement Function",
         "description": "Writing functions in Arduino. Task: Write a function to rotate the robot.",
         "template": "# Write code here"
@@ -112,7 +144,7 @@
       {
         "str_id": "electric_motor",
         "url": "https://raw.githubusercontent.com/autolab-fi/lineRobot-micropython-course/main/lessons/module_3/electric_motor.md",
-        "sn": 10,
+        "sn": 14,
         "name": "Electric Motor",
         "description": "Basic principles of DC motors. Task: Move to a specific point on the map using only functions for controlling motors.",
         "template": "# Write code here"
@@ -129,7 +161,7 @@
         "str_id": "line_sensor_intro",
         "name": "Line Sensor and Black Line Detection",
         "url": "https://raw.githubusercontent.com/autolab-fi/lineRobot-micropython-course/main/lessons/module_5/line_senosor_intro.md",
-        "sn": 12,
+        "sn": 16,
         "description": "This lesson focuses on understanding how an Octoliner sensor detects black lines using IR sensors and implementing black line detection.",
         "template": "# Write code here"
       }
@@ -145,7 +177,7 @@
         "str_id": "introduction_to_variables_and_conditional_statements",
         "name": "Introduction to Variables and Conditional Statements",
         "url": "https://raw.githubusercontent.com/autolab-fi/lineRobot-micropython-course/main/lessons/module_6/Introduction%20to%20Variables%20and%20Conditional%20Statements.md",
-        "sn": 13,
+        "sn": 17,
         "description": "Learn how to declare and use variables in programming, and apply conditional logic using if, else if, and else statements.",
         "template": "# Write code here"
       },
@@ -153,7 +185,7 @@
         "str_id": "loops_and_conditional_logic",
         "name": "Loops and Conditional Logic",
         "url": "https://raw.githubusercontent.com/autolab-fi/lineRobot-micropython-course/main/lessons/module_6/Loops%20and%20Conditional%20Logic.md",
-        "sn": 14,
+        "sn": 18,
         "description": "Learn how to repeat actions using for and while loops combined with conditional statements.",
         "template": "# Write code here"
       },
@@ -161,7 +193,7 @@
         "str_id": "array_and_processing_data",
         "name": "Arrays and Processing Data with Loops",
         "url": "https://raw.githubusercontent.com/autolab-fi/lineRobot-micropython-course/main/lessons/module_6/Arrays%20and%20Processing%20Data%20with%20Loops.md",
-        "sn": 15,
+        "sn": 19,
         "description": "Understand how to use arrays to store and analyze sensor data with systematic data collection.",
         "template": "# Write code here"
       },
@@ -169,7 +201,7 @@
         "str_id": "hello_mqtt_variables",
         "name": "MQTT Greeting of Variables",
         "url": "https://raw.githubusercontent.com/autolab-fi/lineRobot-micropython-course/main/lessons/module_6/MQTT%20Greeting%20of%20Variables.md",
-        "sn": 16,
+        "sn": 20,
         "description": "Declare variables of different types and broadcast them in a single MQTT status line.",
         "template": "# Write code here"
       },
@@ -177,7 +209,7 @@
         "str_id": "mission_time_report",
         "name": "Telemetry: Calculating Time",
         "url": "https://raw.githubusercontent.com/autolab-fi/lineRobot-micropython-course/main/lessons/module_6/Telemetry%20Calculating%20Time.md",
-        "sn": 17,
+        "sn": 21,
         "description": "Compute mission travel time from distance and speed and format it as telemetry.",
         "template": "# Write code here"
       },
@@ -185,7 +217,7 @@
         "str_id": "sensor_log_summary",
         "name": "Sensor Log: List and Aggregates",
         "url": "https://raw.githubusercontent.com/autolab-fi/lineRobot-micropython-course/main/lessons/module_6/Sensor%20Log%20List%20and%20Aggregates.md",
-        "sn": 18,
+        "sn": 22,
         "description": "Summarise a list of sensor readings by reporting the count, values, and average.",
         "template": "# Write code here"
       },
@@ -193,7 +225,7 @@
         "str_id": "list_operations_check",
         "name": "Working with Lists: Adding, Removing, and Measuring",
         "url": "https://raw.githubusercontent.com/autolab-fi/lineRobot-micropython-course/main/lessons/module_6/Working%20with%20Lists%20Adding%20Removing%20and%20Measuring.md",
-        "sn": 19,
+        "sn": 23,
         "description": "Manipulate a mixed-type list and report its contents and length via MQTT.",
         "template": "# Write code here"
       }
@@ -209,7 +241,7 @@
         "str_id": "basic_line_follower",
         "name": "Relay, P, and PI Controllers",
         "url": "https://raw.githubusercontent.com/autolab-fi/lineRobot-micropython-course/main/lessons/module_7/basic_line_follower.md",
-        "sn": 20,
+        "sn": 24,
         "description": "Understand how different types of controllers work \u2014 Relay, Proportional (P), and Proportional-Integral (PI) for line following.",
         "template": "# Write code here"
       },
@@ -217,7 +249,7 @@
         "str_id": "pi",
         "name": "P and PI Controllers",
         "url": "https://raw.githubusercontent.com/autolab-fi/lineRobot-micropython-course/main/lessons/module_7/P%20and%20PI.md",
-        "sn": 21,
+        "sn": 25,
         "description": "Learn about Proportional and Proportional-Integral controllers for improved line following performance.",
         "template": "# Write code here"
       },
@@ -225,7 +257,7 @@
         "str_id": "pid",
         "name": "PID Controller",
         "url": "https://raw.githubusercontent.com/autolab-fi/lineRobot-micropython-course/main/lessons/module_7/PID.md",
-        "sn": 22,
+        "sn": 26,
         "description": "Implement a complete PID controller combining proportional, integral, and derivative terms for optimal line following.",
         "template": "# Write code here"
       }
@@ -241,7 +273,7 @@
         "str_id": "telemetry_heartbeat_health",
         "name": "Telemetry Heartbeat with Status Levels",
         "url": "https://raw.githubusercontent.com/autolab-fi/lineRobot-micropython-course/main/lessons/module_8/Telemetry%20Heartbeat%20with%20Status%20Levels.md",
-        "sn": 23,
+        "sn": 27,
         "description": "Derive a health flag from readiness, speed, and battery data and include it in the STATUS heartbeat.",
         "template": "# Write code here"
       },
@@ -249,7 +281,7 @@
         "str_id": "line_sensor_leds",
         "name": "Line Sensor Reactive LEDs",
         "url": "https://raw.githubusercontent.com/autolab-fi/lineRobot-micropython-course/main/lessons/module_8/Line%20Sensor%20Reactive%20LEDs.md",
-        "sn": 24,
+        "sn": 28,
         "description": "Mirror Octoliner readings to the LEDs using lists and dictionaries, then report the snapshot over MQTT.",
         "template": "# Write code here"
       }
@@ -265,7 +297,7 @@
         "str_id": "fog_of_war_survey",
         "name": "Fog of War Survey",
         "url": "https://raw.githubusercontent.com/autolab-fi/lineRobot-micropython-course/main/lessons/module_9/Fog%20of%20War%20Survey.md",
-        "sn": 25,
+        "sn": 29,
         "description": "Use a snake-pattern sweep to uncover a provided foggy map and stop once coverage passes 90%.",
         "template": "# Write code here"
       },
@@ -273,7 +305,7 @@
         "str_id": "docking",
         "name": "Docking",
         "url": "https://raw.githubusercontent.com/autolab-fi/lineRobot-micropython-course/main/lessons/module_9/Docking.md",
-        "sn": 26,
+        "sn": 30,
         "description": "Implement an auto-docking procedure to navigate the robot to a charging station ",
         "template": "# Write code here"
       }


### PR DESCRIPTION
### Motivation
- Align the `module_1` lessons metadata with the actual lesson files by using each mission's front-matter `task` and `index`, and the H1 lesson titles. 
- Ensure the module lesson order matches the lessons' `index` (1→7) and the `previous/next` relationships in front-matter. 
- Keep global lesson sequence numbers (`sn`) consistent after expanding module 1 so downstream modules remain correctly ordered.

### Description
- Replaced the `lessons` array under the object with `"str_id": "module_1"` in `lessons-list.json` with seven entries corresponding to `mission_1.1.md` through `mission_1.7.md`, using `str_id` from front-matter `task`, `name` from the H1 titles, and `url` pointing to the raw GitHub mission files. 
- Filled each new entry's `description` from the lesson `Objective` or short intro, preserved or left `template` placeholders as-is, and set `sn` values for module 1 to the new sequence (3..9). 
- Shifted `sn` values in later modules to account for the expanded module 1 list so global numbering remains contiguous. 
- Committed the updated `lessons-list.json` to the repository.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69778c293eb8833287d9cf628b543d2e)