### PR TITLE
Module 0: keep sandbox verification only and add optional user_code parameter

### DIFF
--- a/verifications/module_0.py
+++ b/verifications/module_0.py
@@ -3,14 +3,8 @@ import math
 import time
 
 
-def delta_points(point_0, point_1):
-    return math.sqrt(((point_0[0] - point_1[0]) ** 2) +
-                     ((point_0[1] - point_1[1]) ** 2))
-
 # start points for the tasks
 target_points = {
-    'test_drive': [(35, 50), (30, 0)],
-    'license_to_drive': [(35, 50), (30, 0)],
     'sandbox': [(50, 50), (30, 0)]
 }
 
@@ -19,8 +13,6 @@ target_points = {
 # to call a library function directly.
 # However, these functions will be disabled if the corresponding value in the dictionary is set to `True`.
 block_library_functions = {
-    'test_drive': False,
-    'license_to_drive': False,
     'sandbox': False,
 }
 
@@ -34,77 +26,6 @@ def get_block_library_functions(task):
 def get_target_points(task):
     global target_points
     return target_points[task]
-
-
-def test_drive(robot, image, td: dict):
-    """Test for lesson 1: Test drive"""
-
-    # init result dictionary
-    result = {
-        "success": True,
-        "description": "You are amazing! The Robot has completed the assignment",
-        "score": 100
-    }
-    # init test data dictionary
-    if not td:
-        td = {
-            "end_time": time.time() + 10,
-            'time_for_task': 3,
-            "prev_robot_center": None
-        }
-
-    robot_position = robot.get_info()["position"]
-
-    text = "Not recognized"
-    image = robot.draw_info(image)
-
-    # check if robot position is not none and previous robot is not none
-    if  td["prev_robot_center"] is not None and robot_position is not None:
-        # calculate delta position
-        delta_pos = delta_points(robot_position, td["prev_robot_center"])
-        
-        text = f'Robot position: x: {robot_position[0]:0.1f} y: {robot_position[1]:0.1f}'
-        # init time when robot started motion
-        if 'robot_start_move_time' not in td and delta_pos>0.7:
-            td['robot_start_move_time'] = time.time()
-            td["end_time"] = time.time() + td['time_for_task'] + 3
-        # init time when robot finished motion
-        if 'robot_start_move_time' in td and 'robot_end_move_time' not in td and delta_pos<0.7:
-            td['robot_end_move_time'] = time.time()
-
-    # check if task failed
-    if ('robot_end_move_time' not in td and td["end_time"]-1<time.time()
-            ) or ('robot_start_move_time'in td and 'robot_end_move_time' in td and 
-            (td['time_for_task']+0.8<td['robot_end_move_time']-td['robot_start_move_time'] 
-            or td['robot_end_move_time']-td['robot_start_move_time']<td['time_for_task']-0.8)):
-
-        result["success"] = False
-        result["score"] = 0
-        # check reason that task failed
-        if 'robot_start_move_time' in td and ('robot_end_move_time' not in td or 'robot_end_move_time' in td 
-            and td['robot_start_move_time']+td['time_for_task']+0.7<td['robot_end_move_time']):
-            result["description"] = 'It is disappointing, but robot failed the task. The robot moved more than it should have.'
-        else:
-            result["description"] = 'It is disappointing, but robot failed the task. The robot moved less then it should have'
-    
-    # update previous robot position
-    if robot_position:
-        td["prev_robot_center"] = robot_position
-
-    return image, td, text, result
-
-
-def license_to_drive(robot, image, td: dict):
-    """Test for lesson 2: License to drive"""
-    # init test data dictionary
-    if not td:
-        td = {
-            "end_time": time.time() + 10,
-            'time_for_task': 5,
-            "prev_robot_center": None
-        }
-
-    return test_drive(robot, image, td)
 
 
 def restore_trajectory(image, prev_point, point, color, width):
@@ -123,7 +44,7 @@ def draw_trajectory(image, points, color, width, restore):
         prev_point = point
 
 
-def sandbox(robot, image, td: dict):
+def sandbox(robot, image, td: dict, user_code=None):
     """Drawing trajectory at lesson Drawing"""
 
     # init result dictionary


### PR DESCRIPTION
### Motivation
- Module 0 lesson set was simplified to only include the sandbox lesson, so the verification code needed to be aligned with the new lesson list.
- The sandbox verification entrypoint must accept an optional `user_code` argument used by newer verification flows.

### Description
- Removed obsolete verification logic for `test_drive` and `license_to_drive` and the unused helper `delta_points` from `verifications/module_0.py` to reflect the single-lesson layout.
- Reduced `target_points` and `block_library_functions` to only include the `sandbox` task in `verifications/module_0.py`.
- Updated the sandbox verification function signature to `sandbox(robot, image, td: dict, user_code=None)` to accept the optional `user_code` parameter while preserving existing trajectory drawing and messaging behavior.
- Only `verifications/module_0.py` was modified.

### Testing
- No automated tests were run for this change (not requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981ef8bebc88324b6bc97352a711431)