### PR TITLE
Remove 'Mission 1.x' prefixes from Module 1 lesson titles

### DIFF
--- a/lessons/module_1/mission_1.1.md
+++ b/lessons/module_1/mission_1.1.md
@@ -6,7 +6,7 @@ previous:
 next: test_drive
 ---
 
-# Mission 1.1 Welcome to Artemis Support Program
+# Welcome to Artemis Support Program
 
 ## Objective
 
@@ -52,4 +52,4 @@ System check complete!
 
 You have successfully connected to the platform and verified the communication link. In the next mission, we will introduce you to the rover hardware and analyze how this code actually works.
 
-Proceed to Mission 1.2.
+Proceed to next Mission

--- a/lessons/module_1/mission_1.2.md
+++ b/lessons/module_1/mission_1.2.md
@@ -6,7 +6,7 @@ previous: welcome
 next: license_to_drive
 ---
 
-# Mission 1.2 Test drive
+# Test drive
 
 ## Objective
 

--- a/lessons/module_1/mission_1.3.md
+++ b/lessons/module_1/mission_1.3.md
@@ -6,7 +6,7 @@ previous: test_drive
 next: directional_movement
 ---
 
-# Mission 1.3 License to drive
+# License to drive
 
 ## Objective
 

--- a/lessons/module_1/mission_1.4.md
+++ b/lessons/module_1/mission_1.4.md
@@ -6,7 +6,7 @@ previous: license_to_drive
 next: python_variables_&_commands
 ---
 
-# Mission 1.4 Directional Movement
+# Directional Movement
 
 ## Objective
 

--- a/lessons/module_1/mission_1.5.md
+++ b/lessons/module_1/mission_1.5.md
@@ -6,7 +6,7 @@ previous: directional_movement
 next: maneuvering
 ---
 
-# Mission 1.5 Python Variables & Commands
+# Python Variables & Commands
 
 ## Objective
 

--- a/lessons/module_1/mission_1.6.md
+++ b/lessons/module_1/mission_1.6.md
@@ -6,7 +6,7 @@ previous: python_variables_&_commands
 next: sequential_navigation
 ---
 
-# Mission 1.6 Maneuvering
+# Maneuvering
 
 ## Objective
 

--- a/lessons/module_1/mission_1.7.md
+++ b/lessons/module_1/mission_1.7.md
@@ -6,7 +6,7 @@ previous: maneuvering
 next: weekly_challenge_1
 ---
 
-# Mission 1.7 Sequential navigation
+# Sequential navigation
 
 ## Objective
 


### PR DESCRIPTION
### Motivation
- Standardize lesson headings across Module 1 by removing the explicit `Mission 1.x` prefix so titles are cleaner and consistent.
- Keep navigation language generic by using the phrase `Proceed to next Mission` in the welcome lesson footer.
- Normalize file endings where necessary to avoid stray newline inconsistencies.

### Description
- Removed the `Mission 1.x` prefix from the top-level headings in `lessons/module_1/mission_1.2.md` through `lessons/module_1/mission_1.7.md` so headings now read e.g. `# Test drive`, `# License to drive`, etc.
- Ensured the welcome lesson footer uses the generic `Proceed to next Mission` phrasing.
- Fixed missing/extra end-of-file newline inconsistencies in a couple of lesson files for consistent file formatting.

### Testing
- No automated tests were run because this is a content-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988b1528c7083249efe76ed5dab52f5)