### PR TITLE
Update module_1 image links to absolute GitHub URLs

### DIFF
--- a/lessons/module_1/mission_1.1.md
+++ b/lessons/module_1/mission_1.1.md
@@ -28,7 +28,7 @@ Watch the briefing video below to understand the mission:
 
 Before you begin coding, take a moment to understand your workspace.
 
-![Interface](../../images/module-1/Interface1.png)
+![Interface](https://github.com/autolab-fi/lineRobot-micropython-course/blob/main/images/module-1/Interface1.png?raw=true)
 
 * **Red Box:** This area contains the **Mission Briefing** (instructions). Read these carefully.
 * **Yellow Box:** This is the **Code Editor**. Here you will write your Python scripts.
@@ -43,7 +43,7 @@ Let's run a system check to make sure you are connected to the facility. You don
 
 Upload the program to the rover - see the animation below: click the Verify button (Red Arrow), watch the video feed (Blue Box):
 
-![Interface's animation](../../images/module-1/upload.gif)
+![Interface's animation](https://github.com/autolab-fi/lineRobot-micropython-course/blob/main/images/module-1/upload.gif?raw=true)
 
 
 ## Conclusion

--- a/lessons/module_1/mission_1.2.md
+++ b/lessons/module_1/mission_1.2.md
@@ -18,7 +18,7 @@ In this lesson, you will initiate the robot's movement. But before we push the b
 
 Behold the mighty rover who will assist you in learning:
 
-![Picture of the robot](../../images/module-1/robot.jpg)
+![Picture of the robot](https://github.com/autolab-fi/lineRobot-micropython-course/blob/main/images/module-1/robot.jpg?raw=true)
 
 
 ## Theory: The Digital Twin

--- a/lessons/module_1/mission_1.4.md
+++ b/lessons/module_1/mission_1.4.md
@@ -24,7 +24,7 @@ In the previous lesson, you gained insight into **functions** and **parameters**
 **robot.move_backward_distance(dist)** - A function for moving the robot backward by the number of centimeters specified by the parameter **dist**.
 
 Robot directions
-![robot_directions](../../images/module-1/robot_directions.png)
+![robot_directions](https://github.com/autolab-fi/lineRobot-micropython-course/blob/main/images/module-1/robot_directions.png?raw=true)
 
 ## Assignment
 

--- a/lessons/module_1/mission_1.6.md
+++ b/lessons/module_1/mission_1.6.md
@@ -22,7 +22,7 @@ In this mission, you will learn how to orient the robot in space. We will cover 
 
 Below, the image represents the possible directions of the robot's movement.
 
-![robot_directions](https://github.com/autolab-fi/line-robot-curriculum/blob/main/images/module_1/directions.png?raw=true)
+![robot_directions](https://github.com/autolab-fi/lineRobot-micropython-course/blob/main/images/module-1/robot_directions.png?raw=true)
 
 ### 1. Standard Turns (90 Degrees)
 For simple navigation, like a maze or a city grid, we usually turn exactly 90 degrees.


### PR DESCRIPTION
### Motivation
- Ensure images in `lessons/module_1` render reliably by replacing relative paths with absolute GitHub URLs.
- Resolve mismatched/external image references by aligning lesson visuals to repository-hosted assets.

### Description
- Replaced relative image links with absolute GitHub URLs in `lessons/module_1/mission_1.1.md`, `lessons/module_1/mission_1.2.md`, `lessons/module_1/mission_1.4.md`, and `lessons/module_1/mission_1.6.md`.
- Updated the `Interface1.png` and `upload.gif` references in `mission_1.1.md` to use repository absolute URLs.
- Converted the `robot.jpg` reference in `mission_1.2.md` to an absolute URL.
- Switched `robot_directions.png` references in `mission_1.4.md` and `mission_1.6.md` to the repository absolute URL.

### Testing
- No automated tests were run for these content-only documentation changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989c940c0208324a68fbb3c1e31da1b)