### PR TITLE
Add message handling and draw_info call in `welcome()` verification

### DIFF
--- a/verifications/module_1.py
+++ b/verifications/module_1.py
@@ -47,14 +47,22 @@ def welcome(robot, image, td: dict, user_code=None):
         "description": "Connection established! System check complete.",
         "score": 100
     }
+    image = robot.draw_info(image)
+    msg = robot.get_msg()
 
     if not td:
         td = {"start_time": time.time(), "end_time": time.time() + 2}
 
     if time.time() > td["end_time"]:
-        return image, td, "Link: Stable", result
+        text = "Link: Stable"
+        if msg is not None:
+            text = f"Message received: {msg}"
+        return image, td, text, result
     
-    return image, td, "Checking connection...", result
+    text = "Checking connection..."
+    if msg is not None:
+        text = f"Message received: {msg}"
+    return image, td, text, result
 
 
 def test_drive(robot, image, td: dict, user_code=None):


### PR DESCRIPTION
### Motivation
- Make the `welcome()` verification consistent with other modules by drawing info on the image and surface incoming robot messages in the UI while preserving the existing connection-status fallbacks.

### Description
- In `verifications/module_1.py` updated `welcome()` to call `robot.draw_info(image)` and `robot.get_msg()` and to return `"Message received: {msg}"` when a message is present, otherwise falling back to `"Checking connection..."` or `"Link: Stable"`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989d0e17a1c8324948d2a53f54ed058)