### PR TITLE
Fix broken image paths in Module 2 lessons

### DIFF
--- a/lessons/module_2/mission_2.1.md
+++ b/lessons/module_2/mission_2.1.md
@@ -18,7 +18,7 @@ In Module 1, you learned how to drive the rover using built-in commands. But to 
 ### 1. What is an Electric Motor?
 An electric motor is a device that converts electrical energy into mechanical energy using a magnetic field. There are various types of motors, but for our rover, we use Direct Current (DC) brushed motors.
 
-![inside_motor](https://github.com/autolab-fi/line-robot-curriculum/blob/main/images/module_2/inside_motor.jpg?raw=True)
+![inside_motor](https://github.com/autolab-fi/lineRobot-micropython-course/blob/main/images/module-2/inside_motor.jpg?raw=true)
 
 An electric motor consists of two main parts:
 * **Stator:** The stationary outer part that creates a constant magnetic field, which in our case is provided by permanent magnets.
@@ -27,14 +27,14 @@ An electric motor consists of two main parts:
 ### 2. Principle of Operation
 When voltage of different polarities is applied to the brushes, it creates magnetic fields in the coil windings. This causes the rotor to rotate as it constantly pushes against and pulls towards the stator's magnets. It keeps the rotor in motion as long as voltage is supplied.
 
-![motor_animation](https://github.com/autolab-fi/line-robot-curriculum/blob/main/images/module_2/animation.gif?raw=True)
+![motor_animation](https://github.com/autolab-fi/lineRobot-micropython-course/blob/main/images/module-2/animation.gif?raw=true)
 
 ### 3. Gearbox in Electric Motors
 Raw electric motors spin very fast but don't have much pushing power (torque). If we connected wheels directly to the motor shaft, the robot wouldn't be able to move its own weight! 
 
 To fix this, an electric motor can be equipped with a **gearbox**. 
 
-![small_size_gearbox](https://github.com/autolab-fi/line-robot-curriculum/blob/main/images/module_2/small_size_gearbox.jpg?raw=True)
+![small_size_gearbox](https://github.com/autolab-fi/lineRobot-micropython-course/blob/main/images/module-2/small_size_gearbox.jpg?raw=true)
 
 A gearbox transfers the rotational motion from the motor shaft to the mechanism. It consists of a set of gears that greatly increase the maximum torque while reducing the rotational speed. Our rover's geared motors run at a steady **178 RPM** (Revolutions Per Minute).
 
@@ -55,7 +55,7 @@ However, you will not be able to use the built-in robot movement functions. The 
 2. Use `time.sleep()` to wait for the exact amount of time needed to reach the target.
 3. Use `stop()` to stop the motors once the robot is on the point.
 
-![finish_point](https://github.com/autolab-fi/line-robot-curriculum/blob/main/images/module_2/finish_point.jpg?raw=True)
+![finish_point](https://github.com/autolab-fi/lineRobot-micropython-course/blob/main/images/module-2/finish_point.jpg?raw=true)
 
 *Hint: You will need to run the code multiple times, adjusting your `time.sleep()` value until the robot stops exactly on the target!*
 

--- a/lessons/module_2/mission_2.6.md
+++ b/lessons/module_2/mission_2.6.md
@@ -34,7 +34,7 @@ In programming, choosing the right loop changes how the robot thinks.
     * *Logic:* We don't know if the obstacle is 1 meter or 5 meters away. We only know we must stop *before* hitting it.
     * *Code:* "Keep moving **while** `distance_to_wall > 10`."
 
-![for_vs_while](https://github.com/autolab-fi/line-robot-curriculum/blob/main/images/module_2/for_vs_while.jpeg?raw=True)
+![for_vs_while](https://github.com/autolab-fi/lineRobot-micropython-course/blob/main/images/module-2/for_vs_while.jpeg?raw=true)
 
 
 ### 2. The Cycle of Monitoring


### PR DESCRIPTION
### Motivation
- Module 2 lesson pages referenced images using incorrect repository paths and inconsistent query parameters which prevented images from rendering. 
- Links needed to point to the repository's actual `images/module-2` location and use a consistent `raw=true` suffix so the markdown image URLs resolve.

### Description
- Updated image URLs in `lessons/module_2/mission_2.1.md` to point to `https://github.com/autolab-fi/lineRobot-micropython-course/blob/main/images/module-2/` and normalized `?raw=true` for all fixed links. 
- Updated the image URL in `lessons/module_2/mission_2.6.md` to use the same `images/module-2` path and `?raw=true` parameter. 
- Ensured path separators and repository name match the current repository so referenced image files exist at the resolved paths.

### Testing
- Searched lesson files for problematic patterns using `rg` to locate `module_2` image references and confirmed fixes. (succeeded)
- Ran a small Python validation script that parses markdown image links in `lessons/module_2` and verifies each GitHub image link resolves to an existing file path in the repository; the script returned `OK`. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69986d950744832483da1c8bfa8e16e4)