### PR TITLE
module_2.py. skipped early returning in line 160

### DIFF
--- a/verifications/module_2.py
+++ b/verifications/module_2.py
@@ -157,7 +157,7 @@ def electric_motors(robot, image, td: dict, user_code=None):
         except Exception as e:
             print(f"Error loading or processing image: {e}")
             td["data"]["image_error"] = True
-            return image, td, f"Error processing image: {str(e)}", result
+            #return image, td, f"Error processing image: {str(e)}", result
 
     # ===== 2. STATE LOCK =====
     if td["data"].get("completed", False):


### PR DESCRIPTION
line 160
except Exception as e:
    print(f"Error loading or processing image: {e}")
    td["data"]["image_error"] = True
    # don't return — let the task continue without the flag image