### PR TITLE
Add Beginner difficulty badge after lesson objectives

### DIFF
--- a/lessons/module_1/mission_1.2.md
+++ b/lessons/module_1/mission_1.2.md
@@ -12,6 +12,8 @@ next: license_to_drive
 
 Understand the concept of a "Robot Object" and execute your first movement code.
 
+![Beginner](https://img.shields.io/badge/Difficulty-Beginner-green)
+
 ## Introduction
 
 In this lesson, you will initiate the robot's movement. But before we push the button, we need to understand *who* receives our commands.

--- a/lessons/module_1/mission_1.3.md
+++ b/lessons/module_1/mission_1.3.md
@@ -12,6 +12,8 @@ next: directional_movement
 
 Understand the structure of a Python robotics program and write your own code to control the robot.
 
+![Beginner](https://img.shields.io/badge/Difficulty-Beginner-green)
+
 ## Introduction
 
 In this lesson, we are granting you the driver's license. Today, you will be writing the program on your own without the instructor's help. However, first, let's cover some important programming concepts that will help you control the robot effectively.

--- a/lessons/module_1/mission_1.4.md
+++ b/lessons/module_1/mission_1.4.md
@@ -12,6 +12,8 @@ next: python_variables_&_commands
 
 Explore functions for moving the robot a specific distance.
 
+![Beginner](https://img.shields.io/badge/Difficulty-Beginner-green)
+
 ## Introduction
 
 In the past two lessons, we've utilized only one function from the lineRobot library. It's now time to introduce additional functions for controlling the robot: moving backward and moving forward, where the parameter is not the number of seconds but the distance.

--- a/lessons/module_1/mission_1.5.md
+++ b/lessons/module_1/mission_1.5.md
@@ -12,6 +12,8 @@ next: maneuvering
 
 Learn to store data using variables, perform basic arithmetic, and use these variables to control the robot and report its status.
 
+![Beginner](https://img.shields.io/badge/Difficulty-Beginner-green)
+
 ## Introduction
 
 In previous missions, you typed specific numbers directly into the command like `robot.move_forward_distance(20)`. This works for simple tasks, but what if your program becomes huge and you need to change that distance in ten different places?

--- a/lessons/module_1/mission_1.6.md
+++ b/lessons/module_1/mission_1.6.md
@@ -12,6 +12,8 @@ next: sequential_navigation
 
 Master the robot's steering system by learning standard 90-degree turns and precision turning with specific angles.
 
+![Beginner](https://img.shields.io/badge/Difficulty-Beginner-green)
+
 ## Introduction
 
 In the previous missions, you learned to move forward and backward and how to store data in variables. But a robot that can only move in a straight line is not sufficient for free movement across the field.

--- a/lessons/module_1/mission_1.7.md
+++ b/lessons/module_1/mission_1.7.md
@@ -12,6 +12,8 @@ next: electric_motors
 
 Create a complex route visiting multiple waypoints and learn how to document your code using comments.
 
+![Beginner](https://img.shields.io/badge/Difficulty-Beginner-green)
+
 ## Introduction
 
 You have mastered the controls: moving, turning, and using variables. Now, you are ready for your first real navigation.

--- a/lessons/module_10/sandbox.md
+++ b/lessons/module_10/sandbox.md
@@ -4,6 +4,8 @@
 
 Here you can test different functions of the robot. The robot will execute your code for up to 20 seconds.
 
+![Beginner](https://img.shields.io/badge/Difficulty-Beginner-green)
+
 ## Robot Description
 
 This is a differential drive robot based on the ESP32 microcontroller and MicroPython.

--- a/lessons/module_2/mission_2.1.md
+++ b/lessons/module_2/mission_2.1.md
@@ -10,6 +10,8 @@ next: differential_drive
 ## Objective
 Learn about electric motors, gearboxes, and how to manually turn them on and off to reach a specific target.
 
+![Beginner](https://img.shields.io/badge/Difficulty-Beginner-green)
+
 ## Introduction
 In Module 1, you learned how to drive the rover using built-in commands. But to truly master robotics, you need to understand the hardware. In this lesson, you will learn about the basic principles of DC motors and see how electrical energy transforms into physical movement!
 

--- a/lessons/module_2/mission_2.2.md
+++ b/lessons/module_2/mission_2.2.md
@@ -11,6 +11,8 @@ next: defining_functions
 ## Objective
 Learn about Differential Drive kinematics and examine the main challenges related to manual motor control using raw PWM values.
 
+![Beginner](https://img.shields.io/badge/Difficulty-Beginner-green)
+
 ## Introduction
 In the previous mission, you learned how electric motors work and how to turn them on using percentage speeds. But how does the robot actually steer? In this lesson, we will study the kinematics of the robot and learn how to control each wheel independently using raw hardware signals.
 

--- a/lessons/module_2/mission_2.3.md
+++ b/lessons/module_2/mission_2.3.md
@@ -10,6 +10,8 @@ next: for_loops
 ## Objective
 Learn what a function is and how to create your own custom functions in MicroPython.
 
+![Beginner](https://img.shields.io/badge/Difficulty-Beginner-green)
+
 ## Introduction
 In programming, a **function** is a named, reusable block of code that performs a specific task. You can think of it as a recipe or a mini-program inside your main program. 
 

--- a/lessons/module_2/mission_2.4.md
+++ b/lessons/module_2/mission_2.4.md
@@ -11,6 +11,8 @@ next: encoder_theory
 ## Objective
 Learn how to use **for** loops to create complex movement patterns by using the loop counter variable.
 
+![Beginner](https://img.shields.io/badge/Difficulty-Beginner-green)
+
 ## Introduction
 In the last mission, you created a function. You could call that function 4 times to drive in a square. But what if you need to repeat an action 100 times? Or what if you want each movement to be slightly faster or longer than the previous one?
 

--- a/lessons/module_2/mission_2.5.md
+++ b/lessons/module_2/mission_2.5.md
@@ -11,6 +11,8 @@ next: while_loops
 ## Objective
 Learn about encoders and their purpose in precise robot movement.
 
+![Beginner](https://img.shields.io/badge/Difficulty-Beginner-green)
+
 ## Introduction
 Until now, the robot seemed to "just know" how far it traveled. But in reality, it was counting invisible pulses. In this lesson, we will bypass the "smart" library functions and look at the raw feedback from the wheels. By using manual motor control, we can see exactly how the sensors react to every move.
 

--- a/lessons/module_2/mission_2.6.md
+++ b/lessons/module_2/mission_2.6.md
@@ -11,6 +11,8 @@ next: intro_to_octoliner
 ## Objective
 Understand the fundamental logic of **While Loops** compared to For Loops, and use active sensor monitoring to stop a robot with precision.
 
+![Beginner](https://img.shields.io/badge/Difficulty-Beginner-green)
+
 ## Introduction
 Imagine walking towards a wall with your eyes closed. You decide to take exactly 10 steps.
 * If your steps are too long, you hit the wall.

--- a/lessons/module_3/mission_3.1.md
+++ b/lessons/module_3/mission_3.1.md
@@ -11,6 +11,8 @@ next: conditional_logic_reactive
 ## Objective
 Understand the working principle of Infrared (IR) line sensors, establish an I2C connection, and read data from a single central sensor.
 
+![Beginner](https://img.shields.io/badge/Difficulty-Beginner-green)
+
 ## Introduction
 Welcome back, Recruit! Up to this point, your rover has been driving "blind," relying entirely on internal motor encoders to estimate its position. But the lunar surface is unpredictable. To achieve true autonomy, the rover needs "eyes" to observe the ground beneath it.
 

--- a/lessons/module_3/mission_3.2.md
+++ b/lessons/module_3/mission_3.2.md
@@ -11,6 +11,8 @@ next: processing_sensor_data
 ## Objective
 Learn how to use conditional statements (`if/else`) and the `break` command to create reactive behavior, allowing the rover to stop autonomously when a line is detected.
 
+![Beginner](https://img.shields.io/badge/Difficulty-Beginner-green)
+
 ## Introduction
 In the previous mission, you successfully streamed data from the rover's optical sensor. However, the rover merely printed the numbers; it didn't *understand* them. 
 

--- a/lessons/module_3/mission_3.3.md
+++ b/lessons/module_3/mission_3.3.md
@@ -11,6 +11,8 @@ next: reading_multiple_sensors
 ## Objective
 Learn how to use comparison operators, understand Boolean values (`True`/`False`), and encapsulate threshold logic inside a custom Python function.
 
+![Beginner](https://img.shields.io/badge/Difficulty-Beginner-green)
+
 ## Introduction
 In the last mission, you hardcoded a specific number directly into your `if` statement to stop the robot. But what if the lighting conditions in the testing facility change? You would have to hunt through hundreds of lines of code to change that number everywhere! 
 

--- a/lessons/module_3/mission_3.4.md
+++ b/lessons/module_3/mission_3.4.md
@@ -11,6 +11,8 @@ next: led_feedback_system
 ## Objective
 Learn how to read all 8 sensors at once using arrays, extract specific data using indices, and use `elif` statements to determine the line's position.
 
+![Beginner](https://img.shields.io/badge/Difficulty-Beginner-green)
+
 ## Introduction
 Until now, you have been reading a single sensor using `analog_read(index)`. But to follow a path, the rover needs full spatial awareness to know if the line is drifting to the left or to the right.
 

--- a/lessons/module_3/mission_3.5.md
+++ b/lessons/module_3/mission_3.5.md
@@ -11,6 +11,8 @@ next: simple_line_follower
 ## Objective
 Learn the basics of GPIO (General Purpose Input/Output) and control the rover's onboard LED to provide physical visual feedback during a geological scan.
 
+![Beginner](https://img.shields.io/badge/Difficulty-Beginner-green)
+
 ## Introduction
 In the previous mission, your rover successfully scanned the lunar surface and reported the location of basaltic mineral veins to the terminal. However, in the harsh environment of the Moon, Mission Control cannot always stare at a computer screen. 
 

--- a/lessons/module_3/mission_3.6.md
+++ b/lessons/module_3/mission_3.6.md
@@ -11,6 +11,8 @@ next: logical_operators
 ## Objective
 Combine your spatial logic (`elif`) with motor commands to build a Relay (Bang-Bang) controller, allowing the rover to autonomously follow a line.
 
+![Beginner](https://img.shields.io/badge/Difficulty-Beginner-green)
+
 ## Introduction
 You have successfully built a system that scans the ground, extracts specific data points, and reacts using LEDs. But the Artemis rover cannot rely on Mission Control to steer it manually based on blinking lights. 
 

--- a/lessons/module_3/mission_3.7.md
+++ b/lessons/module_3/mission_3.7.md
@@ -11,6 +11,8 @@ next: python_lists
 ## Objective
 Learn how to use `or` and `and` logical operators to combine multiple conditions, eliminating blind spots and detecting complex track features like intersections.
 
+![Beginner](https://img.shields.io/badge/Difficulty-Beginner-green)
+
 ## Introduction
 In the previous mission, your rover successfully drove itself! However, relying on only three "scout" sensors has a major flaw: **blind spots**. If the track has a sharp turn, the line might slip between the scouts, causing the rover to lose the path. 
 

--- a/lessons/module_4/mission_4.1.md
+++ b/lessons/module_4/mission_4.1.md
@@ -11,6 +11,8 @@ next: telemetry_reporting
 ## Objective
 Create Python lists, determine their size using `len()`, and use a `for` loop to execute a multi-step navigation route.
 
+![Beginner](https://img.shields.io/badge/Difficulty-Beginner-green)
+
 ## Introduction
 Welcome to Module 4, Recruit! 
 In the previous module, you encountered arrays when reading data from the Octoliner sensor using `octoliner.analog_read_all()`. You learned that an array (or list) can hold multiple numbers at once. 

--- a/lessons/module_4/mission_4.2.md
+++ b/lessons/module_4/mission_4.2.md
@@ -11,6 +11,8 @@ next: color_sensor_basics
 ## Objective
 Learn how to track real-world execution time, perform mathematical operations to calculate the robot's actual speed, and construct structured telemetry reports using Python f-strings.
 
+![Beginner](https://img.shields.io/badge/Difficulty-Beginner-green)
+
 ## Introduction
 Welcome back to Mission Control! While your rover executes its routes, it must constantly report its status and sensor data back to the base—a process known as **telemetry**.
 

--- a/lessons/module_4/mission_4.3.md
+++ b/lessons/module_4/mission_4.3.md
@@ -11,6 +11,8 @@ next: color_classification
 ## Objective
 Understand the RGB color model, initialize the TCS34725 color sensor via the I2C interface, and read raw color data from the lunar surface across multiple zones.
 
+![Beginner](https://img.shields.io/badge/Difficulty-Beginner-green)
+
 ## Introduction
 Your rover is now fully capable of navigating and reporting its physical status. However, to conduct true scientific research, it needs to analyze the geological composition of the ground. 
 

--- a/lessons/module_4/mission_4.4.md
+++ b/lessons/module_4/mission_4.4.md
@@ -11,6 +11,8 @@ next: multiple_sensors
 ## Objective
 Learn how to process raw sensor data, understand color normalization, and write a custom Python function to classify RGB values into human-readable colors.
 
+![Beginner](https://img.shields.io/badge/Difficulty-Beginner-green)
+
 ## Introduction
 In the previous mission, your rover successfully scanned the terrain and printed raw RGB (Red, Green, Blue) values. However, raw numbers are hard for humans to read, and even harder for a robot to use for making decisions. 
 

--- a/lessons/module_4/mission_4.5.md
+++ b/lessons/module_4/mission_4.5.md
@@ -11,6 +11,8 @@ next: data_logging
 ## Objective
 Combine the Octoliner and the Color Sensor in a single program. The rover must autonomously follow a black line while simultaneously scanning the ground, using an LED to signal anomalies without stopping.
 
+![Beginner](https://img.shields.io/badge/Difficulty-Beginner-green)
+
 ## Introduction
 Up until now, your rover has been doing one job at a time: either following a line blindly or scanning colors while driving straight. Real Lunar rovers perform multiple tasks simultaneously. 
 

--- a/lessons/module_4/mission_4.6.md
+++ b/lessons/module_4/mission_4.6.md
@@ -11,6 +11,8 @@ next: concept_of_error
 ## Objective
 Transform the rover into a silent data-collection probe. It must drive autonomously for 30 seconds, memorize all color anomalies in its RAM, and print a formatted summary report when the mission ends.
 
+![Beginner](https://img.shields.io/badge/Difficulty-Beginner-green)
+
 ## Introduction
 In Mission 4.5, your rover reacted to anomalies in real-time. But deep space probes operate differently: they collect data silently to save power, store it in their memory, and transmit a giant data log back to Earth only when the scanning run is complete. 
 

--- a/lessons/module_5/mission_5.1.md
+++ b/lessons/module_5/mission_5.1.md
@@ -11,6 +11,8 @@ next: failsafe_protocols
 ## Objective
 Understand the limitations of a Relay (Bang-Bang) controller and introduce the concept of "Error" as a continuous gradient using the advanced `track_line()` function.
 
+![Beginner](https://img.shields.io/badge/Difficulty-Beginner-green)
+
 ## Introduction
 Welcome to Module 5, Recruit!
 In Module 3, you built your first autonomous line follower. It successfully navigated the track, but the ride wasn't exactly smooth. The rover wobbled back and forth aggressively. That algorithm is known as a **Relay Controller** (or "Bang-Bang").

--- a/lessons/module_5/mission_5.2.md
+++ b/lessons/module_5/mission_5.2.md
@@ -11,6 +11,8 @@ next: proportional_control
 ## Objective
 Learn how to use the sensor's auto-calibration feature and build an upgraded Relay (Bang-Bang) controller using the continuous Error variable and a `NaN` failsafe.
 
+![Beginner](https://img.shields.io/badge/Difficulty-Beginner-green)
+
 ## Introduction
 In Module 3, you built a Relay Controller by checking multiple individual sensors (Index 1, 3, 6) to decide whether to turn left or right. It worked, but the code was long and complex.
 

--- a/lessons/module_5/mission_5.3.md
+++ b/lessons/module_5/mission_5.3.md
@@ -11,6 +11,8 @@ next: tuning_and_kick
 ## Objective
 Understand the mathematical concept of Proportional Control and write a P-controller algorithm to smoothly steer the rover based on the continuous Error gradient.
 
+![Beginner](https://img.shields.io/badge/Difficulty-Beginner-green)
+
 ## Introduction
 Your Upgraded Relay Controller in the last mission was smart, but it still wobbled. Why? 
 Because it still turned at a *fixed* speed, regardless of the situation. Whether the rover drifted 2 millimeters or 5 centimeters off the line, it applied the exact same turning force. 

--- a/lessons/module_5/mission_5.4.md
+++ b/lessons/module_5/mission_5.4.md
@@ -11,6 +11,8 @@ next: adaptive_speed
 ## Objective
 Understand the effects of the Proportional Coefficient (*K_p*) on system stability, tune it for optimal performance, and implement a "Software Kick" to test the controller's recovery capabilities.
 
+![Beginner](https://img.shields.io/badge/Difficulty-Beginner-green)
+
 ## Introduction
 In the last mission, you built a working Proportional Controller. But as you probably noticed, guessing the *K_p* value (like `10`) doesn't always result in a perfect ride. 
 

--- a/lessons/module_5/mission_5.5.md
+++ b/lessons/module_5/mission_5.5.md
@@ -11,6 +11,8 @@ next: module_6_intro
 ## Objective
 Make the rover race-ready by implementing an Adaptive Speed algorithm that automatically slows down before corners using the `abs()` function.
 
+![Beginner](https://img.shields.io/badge/Difficulty-Beginner-green)
+
 ## Introduction
 Your Proportional Controller is stable, but it has a flaw: it drives at a constant `base_speed`. 
 If you set the speed to `30`, the robot easily navigates sharp corners, but crawls agonizingly slowly on straightaways. If you increase the speed to `80`, it flies down the straights but crashes on the first sharp turn because it's going too fast to steer!

--- a/lessons/module_6/Arrays and Processing Data with Loops.md
+++ b/lessons/module_6/Arrays and Processing Data with Loops.md
@@ -6,6 +6,8 @@ Understand how to use arrays to store and analyze sensor data.
 
 ---
 
+![Beginner](https://img.shields.io/badge/Difficulty-Beginner-green)
+
 ## **Introduction**
 
 Arrays allow you to store multiple values under one name. For robotics applications, arrays are perfect for handling multiple sensor readings, storing historical data, or tracking patterns over time. Instead of creating separate variables for each measurement, arrays group them together, making it easier to loop through and analyze data.

--- a/lessons/module_6/Introduction to Variables and Conditional Statements.md
+++ b/lessons/module_6/Introduction to Variables and Conditional Statements.md
@@ -6,6 +6,8 @@ Learn how to declare and use variables in programming, and apply conditional log
 
 ---
 
+![Beginner](https://img.shields.io/badge/Difficulty-Beginner-green)
+
 ## **Introduction**
 
 Variables are essential in microcontroller programming for storing information like sensor readings, motor speeds, and system states. In robot programming, we use conditional statements to make decisions based on these variables, creating intelligent behavior.

--- a/lessons/module_6/Loops and Conditional Logic.md
+++ b/lessons/module_6/Loops and Conditional Logic.md
@@ -6,6 +6,8 @@ Learn how to repeat actions using `for` and `while` loops.
 
 ---
 
+![Beginner](https://img.shields.io/badge/Difficulty-Beginner-green)
+
 ## **Introduction**
 
 Loops are essential for microcontrollers perform repeated actions. Using loops saves you from writing the same code over and over, making your programs more efficient and easier to maintain.

--- a/lessons/module_6/MQTT Greeting of Variables.md
+++ b/lessons/module_6/MQTT Greeting of Variables.md
@@ -6,6 +6,8 @@ Declare variables of multiple types and publish them in a single MQTT-style stat
 
 ---
 
+![Beginner](https://img.shields.io/badge/Difficulty-Beginner-green)
+
 ## **Introduction**
 
 Robots often send compact updates about their status to a control dashboard. MicroPython variables let us store the information we want to broadcast—such as the robot name, speed, battery voltage, and readiness flag. In this lesson we will gather those values and format them into one line that begins with `STATUS:` so it can be parsed by the checker.

--- a/lessons/module_6/Sensor Log List and Aggregates.md
+++ b/lessons/module_6/Sensor Log List and Aggregates.md
@@ -6,6 +6,8 @@ Collect multiple sensor readings in a list, compute summary values, and broadcas
 
 ---
 
+![Beginner](https://img.shields.io/badge/Difficulty-Beginner-green)
+
 ## **Introduction**
 
 Robots rarely rely on a single measurement. By storing successive readings in a list we can determine how many samples we have, display them together, and report statistics such as the average. The verification tool listens for three separate `LOG:` messages that must agree with each other, so careful formatting is important.

--- a/lessons/module_6/Telemetry Calculating Time.md
+++ b/lessons/module_6/Telemetry Calculating Time.md
@@ -6,6 +6,8 @@ Calculate mission travel time using distance and speed, then publish it in an MQ
 
 ---
 
+![Beginner](https://img.shields.io/badge/Difficulty-Beginner-green)
+
 ## **Introduction**
 
 Mission control dashboards need to know how long the robot will take to travel to a checkpoint. By dividing a known distance by the current speed, we can estimate the travel time and broadcast it as a `MISSION:` message. This lesson shows how to perform the calculation, round it to a readable value, and send the result for verification.

--- a/lessons/module_6/Working with Lists Adding Removing and Measuring.md
+++ b/lessons/module_6/Working with Lists Adding Removing and Measuring.md
@@ -6,6 +6,8 @@ Practise modifying mixed-type lists using `append()`, `pop()`, and `del`, then p
 
 ---
 
+![Beginner](https://img.shields.io/badge/Difficulty-Beginner-green)
+
 ## **Introduction**
 
 Lists can store any combination of values: strings for names, integers for speeds, floats for voltages, and booleans for readiness flags. Changing the list while the program runs is a powerful way to keep track of robot state. In this lesson we will adjust a list and report both its contents and its length to confirm the operations.

--- a/lessons/module_7/PID.md
+++ b/lessons/module_7/PID.md
@@ -10,6 +10,8 @@ So far, we’ve seen how the proportional term reacts to present error and how t
 
 If the robot is correcting too aggressively, the derivative slows things down before it overshoots. This makes the system more stable and less wobbly.
 
+![Beginner](https://img.shields.io/badge/Difficulty-Beginner-green)
+
 ## ![Pid](https://github.com/pranavk-2003/line-robot-curriculum/blob/assignments/images/module_8/pid_f.png?raw=True)
 
 ### The Full PID Formula

--- a/lessons/module_7/basic_line_follower.md
+++ b/lessons/module_7/basic_line_follower.md
@@ -26,6 +26,8 @@ This results in a zigzag movement. The robot overcorrects and keeps switching di
 
 ---
 
+![Beginner](https://img.shields.io/badge/Difficulty-Beginner-green)
+
 ## **Programming the Line Following Algorithm to use a Relay Controller**
 
 This code will:

--- a/lessons/module_8/Analog LED Fade.md
+++ b/lessons/module_8/Analog LED Fade.md
@@ -3,6 +3,8 @@
 ## Lesson objective
 Build confidence using Python loops and timing to repeat LED actions.
 
+![Beginner](https://img.shields.io/badge/Difficulty-Beginner-green)
+
 ## Introduction
 Loops let you repeat a block of code without copying the same command over and over. When you pair a loop with a short delay, you can choreograph LED flashes that communicate what the robot just sensed. This lesson practises counting iterations, waiting between flashes, and mapping sensor readings to a visible signal.
 

--- a/lessons/module_8/Line Sensor Reactive LEDs.md
+++ b/lessons/module_8/Line Sensor Reactive LEDs.md
@@ -3,6 +3,8 @@
 ## Lesson objective
 Understand how Python lists store ordered data and practise turning list decisions into LED feedback.
 
+![Beginner](https://img.shields.io/badge/Difficulty-Beginner-green)
+
 ## Introduction
 Lists are Python's flexible containers for ordered values. They let you group readings, configuration numbers, or status text so the items stay in sequence. Once you can gather data in a list and access positions by index, you can reuse the same pattern for sensors, LED patterns, or any other structured information.
 

--- a/lessons/module_8/Telemetry Heartbeat with Status Levels.md
+++ b/lessons/module_8/Telemetry Heartbeat with Status Levels.md
@@ -3,6 +3,8 @@
 ## Lesson objective
 Understand how Python dictionaries store related information with named keys.
 
+![Beginner](https://img.shields.io/badge/Difficulty-Beginner-green)
+
 ## Introduction
 Dictionaries pair keys with values so you can label the data you gather. They make it easy to keep related facts together, update individual pieces, and look them up by name. In this lesson you will practise building small telemetry dictionaries and turning their contents into readable status summaries.
 

--- a/lessons/module_9/Coordinate Navigation Log.md
+++ b/lessons/module_9/Coordinate Navigation Log.md
@@ -3,6 +3,8 @@
 ## Lesson objective
 Interpret a target coordinate on a mapped grid, drive the robot to that point, confirm arrival, and publish a navigation log that includes the mineral found in Lesson 2.
 
+![Beginner](https://img.shields.io/badge/Difficulty-Beginner-green)
+
 ## Introduction
 Mission Control now transmits exact `(x, y)` coordinates on the exploration map. Your rover must read the grid, plot a route, and verify when it reaches the destination. When you arrive, you will report both the final position and the mineral the scanner detected earlier.
 

--- a/lessons/module_9/Docking.md
+++ b/lessons/module_9/Docking.md
@@ -3,6 +3,8 @@
 ## Lesson objective
 Make the rover dock with the charging station and report the charging status.
 
+![Beginner](https://img.shields.io/badge/Difficulty-Beginner-green)
+
 ## Introduction
 After a long exploration mission, your rover needs to recharge. In this lesson, you will implement an auto-docking sequence that guides the robot backward to find its charging station. The robot will continuously monitor its charging status and stop when it successfully makes contact with the charging pads.
 

--- a/lessons/module_9/Fog of War Survey.md
+++ b/lessons/module_9/Fog of War Survey.md
@@ -3,6 +3,8 @@
 ## Lesson Objective
 Program the robot to systematically explore and reveal a fog-covered terrain map by executing a repeatable movement pattern that uncovers at least 60% of the hidden surface.
 
+![Beginner](https://img.shields.io/badge/Difficulty-Beginner-green)
+
 ## Introduction
 Mission Control provides a partially obscured map—only areas the robot physically visits will be revealed. Your task is to write a sequence of movements that can be repeated to efficiently survey the landing zone, uncovering more than half the terrain without manually controlling each step.
 

--- a/lessons/module_9/Mineral Scanner Sweep.md
+++ b/lessons/module_9/Mineral Scanner Sweep.md
@@ -3,6 +3,8 @@
 ## Lesson Objective
 Navigate to 5 different scanning zones, activate the detection system at each location for 2 seconds to reveal minerals, wait 3 seconds for collection, then proceed to the next zone.
 
+![Beginner](https://img.shields.io/badge/Difficulty-Beginner-green)
+
 ## Introduction
 Mission Control has identified 5 mineral-rich zones in your survey area. Your robot must systematically visit each zone, activate its scanner LEDs to reveal what minerals are present, wait for the collection system to gather samples, then move to the next location. This multi-waypoint survey mission requires precise timing and navigation.
 


### PR DESCRIPTION
### Motivation
- Make the lesson pages consistent with Mission 1.1 by showing a difficulty level immediately after each objective. 
- Provide an explicit, visual cue for learners (using the same `Beginner` level for now) across lessons that include an objective section. 
- Keep this as a content-only change so the course structure and runtime code are untouched.

### Description
- Inserted the badge `![Beginner](https://img.shields.io/badge/Difficulty-Beginner-green)` directly after the `## Objective` / `## Lesson objective` sections in lesson markdown files across modules 1–10. 
- Applied the badge to all lesson files that contain an objective heading (detected with a small pattern match), covering multiple `module_*/*.md` files. 
- The change was implemented with a short Python script that locates the objective heading and injects the badge while preserving surrounding whitespace. 
- This is a markdown-only update; no runtime code or library files were modified.

### Testing
- Ran a detection script (`python` snippet using `re.search` over `lessons/module_*/*.md`) to ensure every file with an objective heading now contains the badge, and the script reported `OK`. 
- Executed the insertion script which printed the list of modified lesson files (changes applied to the intended files) and verified the diffs to confirm the badge was placed immediately after the objective paragraphs. 
- No automated runtime tests were required because this is a documentation-only change and the verification script succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4e359c21c832499c7df66eee97fa6)