### PR TITLE
Clarify print() function output location

### DIFF
--- a/lessons/module_1/mission_1.5.md
+++ b/lessons/module_1/mission_1.5.md
@@ -53,7 +53,7 @@ robot.move_forward_distance(step)
 ```
 
 ### 4. The `print()` function
-Robots need to talk back to us. The `print()` command writes text to the console (the output window). You can print text and variables together by separating them with commas.
+Robots need to talk back to us. The `print()` command writes text to the Robot MQTT log - next to the robot in the video. You can print text and variables together by separating them with commas.
 
 ```python
 dist = 100


### PR DESCRIPTION
Updated the explanation of the print() function to clarify that it writes to the Robot MQTT log instead of the console.